### PR TITLE
software: Fixes for 03.Prisma

### DIFF
--- a/software/03.Prisma/README.md
+++ b/software/03.Prisma/README.md
@@ -46,7 +46,7 @@ Create the `removePost` function:
 
 ## Step 3: Apollo Server and Nexus
 
-Prisma allows us to retrieve data from the database, but we then have to allow the users to retrieve this data. We will use [GraphQL Nexus](https://nexus.js.org/) and [Apollo server](https://www.apollographql.com/docs/apollo-server/) for this purpose.
+Prisma allows us to retrieve data from the database, but we then have to allow the users to retrieve this data. We will use [GraphQL Nexus](https://nexusjs.org/) and [Apollo server](https://www.apollographql.com/docs/apollo-server/) for this purpose.
 
 You will have to install new packages to do this:
 

--- a/software/03.Prisma/SETUP.md
+++ b/software/03.Prisma/SETUP.md
@@ -36,6 +36,10 @@ You can also display the database via a web interface:
 ```sh
 npx prisma studio
 ```
+:bulb: If you have an error while running this command, try to update the `prisma` packages:
+```
+npm add -D prisma@3.15.0 && npm add @prisma/client@3.15.0
+```
 
 ## Prisma in javascript code
 


### PR DESCRIPTION
# Description

While doing this workshop on my own, I noticed two problems fixed in this PR:
- A wrong link to Nexus
- A wrong version of `prisma` in the SETUP that causes an error on new OSs (Fedora 36, Ubuntu 22.04...)
For more details, https://github.com/prisma/prisma/issues/11356.
This version change doesn't impact the rest of the workshop.

PS: This workshop should be completely refactored as it's not using Prisma2 anymore in the first 2 steps (the starter code is downloaded from the official repo which is using v3.x
Prisma 4.0 was released 2 days ago, a workshop based on it could be great.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have tested this code
- [ ] I have added sufficient documentation in the code