### PR TITLE
[FIX] broken openai gym links

### DIFF
--- a/ai/DQN/README.md
+++ b/ai/DQN/README.md
@@ -17,7 +17,7 @@ You will:
 ## Documentation
 
 - [DQN Paper](https://web.stanford.edu/class/psych209/Readings/MnihEtAlHassibis15NatureControlDeepRL.pdf)
-- [LunarLander Environment](https://www.gymlibrary.ml/environments/box2d/lunar_lander/)
+- [LunarLander Environment](https://www.gymlibrary.dev/environments/box2d/lunar_lander/)
 - [PyTorch Docs](https://pytorch.org/docs/stable/index.html)
 
 ## Getting Started

--- a/ai/DQN/dqn.ipynb
+++ b/ai/DQN/dqn.ipynb
@@ -588,7 +588,7 @@
     "    - maybe you can change the sizes of the hidden layers or their amount\n",
     "- Turn this DQN into a [DoubleDQN](https://arxiv.org/pdf/1509.06461.pdf)\n",
     "- Remove the `target_network` entirely by using [DeepMellow](https://cs.brown.edu/~gdk/pubs/deepmellow.pdf)\n",
-    "- Try out [other environments](https://www.gymlibrary.ml/#): only some minor changes are required for most algorithms. For [Atari games](https://www.gymlibrary.ml/environments/atari/), for example, you only need to preprocess the observations using [gym wrappers](https://www.gymlibrary.ml/content/wrappers/) and use [convolutions](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html). Be warned, though, because the Atari environments will take a <bold>lot</bold> longer to train than LunarLander !"
+    "- Try out [other environments](https://www.gymlibrary.dev/#): only some minor changes are required for most algorithms. For [Atari games](https://www.gymlibrary.dev/environments/atari/), for example, you only need to preprocess the observations using [gym wrappers](https://www.gymlibrary.dev/content/wrappers/) and use [convolutions](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html). Be warned, though, because the Atari environments will take a <bold>lot</bold> longer to train than LunarLander !"
    ]
   }
  ],

--- a/ai/Reinforcement_Learning/README.md
+++ b/ai/Reinforcement_Learning/README.md
@@ -10,8 +10,8 @@ You will:
 ## Documentation
 
 - [Q-Learning](https://en.wikipedia.org/wiki/Q-learning)
-- [Gym](https://www.gymlibrary.ml/)
-- [FrozenLake](https://www.gymlibrary.ml/environments/toy_text/frozen_lake/)
+- [Gym](https://www.gymlibrary.dev/)
+- [FrozenLake](https://www.gymlibrary.dev/environments/toy_text/frozen_lake/)
 
 ## Getting Started
 

--- a/ai/Reinforcement_Learning/Reinforcement_Learning.ipynb
+++ b/ai/Reinforcement_Learning/Reinforcement_Learning.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "1. Learn about Q Tables\n",
     "2. Setup a gym environment\n",
-    "3. Train an AI to solve the [FrozenLake environment](https://www.gymlibrary.ml/environments/toy_text/frozen_lake/)\n",
+    "3. Train an AI to solve the [FrozenLake environment](https://www.gymlibrary.dev/environments/toy_text/frozen_lake/)\n",
     "\n",
     "Let's start by importing the required libraries:"
    ]
@@ -165,10 +165,10 @@
     "#### What is Gym ?\n",
     "> Gym is a standard API for reinforcement learning, and a diverse collection of reference environments\n",
     ">\n",
-    "> -- <cite>[Gym Docs](https://www.gymlibrary.ml/#gym-is-a-standard-api-for-reinforcement-learning-and-a-diverse-collection-of-reference-environments)</cite>\n",
+    "> -- <cite>[Gym Docs](https://www.gymlibrary.dev/#gym-is-a-standard-api-for-reinforcement-learning-and-a-diverse-collection-of-reference-environments)</cite>\n",
     "\n",
     "Let's get to the fun part:\n",
-    "Read the documentation for FrozenLake [here](https://www.gymlibrary.ml/environments/toy_text/frozen_lake/)\n",
+    "Read the documentation for FrozenLake [here](https://www.gymlibrary.dev/environments/toy_text/frozen_lake/)\n",
     "and find out how to load the environment.\n",
     "\n",
     "For now, we will set the `is_slippery` variable to `False` \n"
@@ -543,10 +543,10 @@
     "If you want to continue in the wonderful world of reinforcement learning, you could try:\n",
     "- Try and increase the accuracy by using different methods of reinforcement learning.\n",
     "- A custom map for Frozen Lake. For example: `gym.make('FrozenLake-v1', map_name=\"8x8\", is_slippery=True)`\n",
-    "- A different environment from https://www.gymlibrary.ml/\n",
+    "- A different environment from https://www.gymlibrary.dev/\n",
     "- Going **deeper** with https://pytorch.org/tutorials/intermediate/reinforcement_q_learning.html\n",
     "- Trying what you've learned with games you know and love:\n",
-    "    - https://www.gymlibrary.ml/environments/atari/\n",
+    "    - https://www.gymlibrary.dev/environments/atari/\n",
     "    - https://pypi.org/project/gym-super-mario-bros/"
    ]
   }


### PR DESCRIPTION
# Description

The openai gym site changed from `.ml` to `.dev` so all the links were broken

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have tested this code
- [X] I have added sufficient documentation in the code